### PR TITLE
feature: add `Eq` trait derivation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "currency-iso4217"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["EBDS Rust Developers"]
 description = "ISO 4217 currency codes"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use std::fmt;
 #[repr(u32)]
 #[rustfmt::skip]
 #[allow(clippy::zero_prefixed_literal)]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Currency {
     /// United Arab Emirates dirham United Arab Emirates


### PR DESCRIPTION
Adds the `Eq` trait derivation for the `Currency` enum.

Bumps the patch release version to `v0.1.2`